### PR TITLE
fix undefined module

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -1417,7 +1417,7 @@ vendor/lib64/libthermalioctl.so
 -vendor/lib64/libthermalclient.so
 
 # Time services - from jasmine-user 10 QKQ1.190910.002 V11.0.5.0.QDIMIXM release-keys
--vendor/app/TimeService/TimeService.apk;:timeservice_app_cert-legacy-um|27f9b81621c446baa8c37581d9bfbca2fd67b496
+-vendor/app/TimeService/TimeService.apk;:timeservice_app_cert|27f9b81621c446baa8c37581d9bfbca2fd67b496
 vendor/bin/time_daemon|d647fa02dfb28b6cb981c4e77daee75a67406351
 vendor/etc/init/init.time_daemon.rc|b253ca2a498757e14e1d7a051bf504ae09218f51
 -vendor/lib/libtime_genoff.so|e858cc52e829af0a9e4b5a4c39bddef8cece4bd9


### PR DESCRIPTION
Error:
vendor/xiaomi/whyred/Android.bp:188:1: "TimeService" depends on undefined module "timeservice_app_cert-legacy-um" 14:15:17 soong bootstrap failed with: exit status 1

Reflect change on vendor/Android.bp also